### PR TITLE
workflow: use fuchsia clang to build llvm

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo pacman -Syu --noconfirm
-          sudo pacman -S --noconfirm --needed git ninja cmake meson clang lld libc++ llvm wget mimalloc
+          sudo pacman -S --noconfirm --needed git ninja cmake meson wget mimalloc go
           mkdir -p /home/opt/7zip
           wget -qO - https://www.7-zip.org/a/7z2301-linux-x64.tar.xz | tar -xJf - -C /home/opt/7zip 7zzs
           sudo ln -s /home/opt/7zip/7zzs /usr/bin/7z
@@ -68,6 +68,9 @@ jobs:
           git config --global pull.rebase true
           git config --global rebase.autoStash true
           git config --global fetch.prune true
+          sudo GOBIN=/usr/bin go install go.chromium.org/luci/cipd/client/cmd/...@latest
+          sudo bash -c "cipd ensure -ensure-file-output /dev/null -root /usr/local/fuchsia-clang -log-level error -ensure-file <(echo 'fuchsia/third_party/clang/linux-amd64 latest')"
+          echo "PATH=/usr/local/fuchsia-clang/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Checkout toolchain
         uses: actions/checkout@v4

--- a/.github/workflows/mpv.yml
+++ b/.github/workflows/mpv.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           sudo echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           sudo pacman -Syu --noconfirm
-          sudo pacman -S --noconfirm --needed git ninja cmake meson clang lld libc++ unzip ragel yasm nasm gperf rst2pdf lib32-gcc-libs lib32-glib2 python-cairo curl wget mimalloc ccache
+          sudo pacman -S --noconfirm --needed git ninja cmake meson clang lld unzip ragel yasm nasm gperf rst2pdf lib32-gcc-libs lib32-glib2 python-cairo curl wget mimalloc ccache
           mkdir -p /home/opt/7zip
           wget -qO - https://www.7-zip.org/a/7z2301-linux-x64.tar.xz | tar -xJf - -C /home/opt/7zip 7zzs
           sudo ln -s /home/opt/7zip/7zzs /usr/bin/7z

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           sudo echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           sudo pacman -Syu --noconfirm
-          sudo pacman -S --noconfirm --needed git ninja cmake meson libc++ wget mimalloc
+          sudo pacman -S --noconfirm --needed git ninja cmake meson wget mimalloc
           mkdir -p /home/opt/7zip
           wget -qO - https://www.7-zip.org/a/7z2301-linux-x64.tar.xz | tar -xJf - -C /home/opt/7zip 7zzs
           sudo ln -s /home/opt/7zip/7zzs /usr/bin/7z


### PR DESCRIPTION
This removed llvm's runtime dependencies on libc++, libgcc (statically linked to libc++, libc++abi, libunwind, compiler-rt) and speeds up llvm builds. The fuchsia clang was chosen because it is built and tested by chromium luci with two-stages bootstrap LTO+PGO and from llvm main branch, so it has the latest optimizations and features of llvm main with guaranteed quality.