### PR TITLE
ci: enable ThinLTO for PGO build

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -111,8 +111,8 @@ jobs:
         with:
           bit: "64-v3"
           compiler: "clang"
-          command: "ninja -C $buildroot/build$bit llvm"
-          extra_option: "-DLLVM_ENABLE_PGO=USE -DLLVM_PROFDATA_FILE=$buildroot/llvm.profdata"
+          command: "ninja -C $buildroot/build$bit llvm && rm -rf clang_root/llvm-thinlto || true"
+          extra_option: "-DLLVM_ENABLE_PGO=USE -DLLVM_ENABLE_LTO=Thin -DLLVM_PROFDATA_FILE=$buildroot/llvm.profdata"
 
       - name: Save llvm cache
         uses: actions/cache/save@v4.0.2


### PR DESCRIPTION
since we've switched to fuchsia clang, the cost of ThinLTO construction has been greatly reduced, and we don't really need to enable ThinLTO for instrumented LLVM. ref: https://github.com/llvm/llvm-project/issues/59506#issuecomment-1351178416

This is only for PGO build. For users who only build mpv occasionally and really care about the 15 minutes of extra build time, there is the option of not using PGO or using GCC toolchain, which will still be supported for a long time to come.